### PR TITLE
Add Proper Command-Based Structure

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/MecanumDriveCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/MecanumDriveCommand.java
@@ -18,15 +18,13 @@ public class MecanumDriveCommand extends CommandBase {
         this.leftX = leftX;
         this.leftY = leftY;
         this.rightX = rightX;
+
+        addRequirements(drive);
     }
 
     @Override
     public void execute() {
-        drive.drive(new Pose2d(
-                -leftY.getAsDouble(),
-                -leftX.getAsDouble(),
-                -rightX.getAsDouble()
-        ));
+        drive.drive(leftY.getAsDouble(), leftX.getAsDouble(), rightX.getAsDouble());
     }
 
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TrajectoryFollowerCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TrajectoryFollowerCommand.java
@@ -1,0 +1,38 @@
+package org.firstinspires.ftc.teamcode.commands;
+
+import com.acmerobotics.roadrunner.geometry.Pose2d;
+import com.acmerobotics.roadrunner.trajectory.Trajectory;
+import com.arcrobotics.ftclib.command.CommandBase;
+
+import org.firstinspires.ftc.teamcode.subsystems.MecanumDriveSubsystem;
+
+public class TrajectoryFollowerCommand extends CommandBase {
+
+    private final MecanumDriveSubsystem drive;
+    private final Trajectory trajectory;
+
+    public TrajectoryFollowerCommand(MecanumDriveSubsystem drive, Trajectory trajectory) {
+        this.drive = drive;
+        this.trajectory = trajectory;
+
+        addRequirements(drive);
+    }
+
+    @Override
+    public void initialize() {
+        drive.followTrajectory(trajectory);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        if (interrupted) {
+            drive.stop();
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return Thread.currentThread().isInterrupted() || !drive.isBusy();
+    }
+
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TurnCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TurnCommand.java
@@ -1,0 +1,34 @@
+package org.firstinspires.ftc.teamcode.commands;
+
+import com.arcrobotics.ftclib.command.CommandBase;
+
+import org.firstinspires.ftc.teamcode.subsystems.MecanumDriveSubsystem;
+
+public class TurnCommand extends CommandBase {
+
+    private final MecanumDriveSubsystem drive;
+    private final double angle;
+
+    public TurnCommand(MecanumDriveSubsystem drive, double angle) {
+        this.drive = drive;
+        this.angle = angle;
+    }
+
+    @Override
+    public void initialize() {
+        drive.turn(angle);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        if (interrupted) {
+            drive.stop();
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return Thread.currentThread().isInterrupted() || !drive.isBusy();
+    }
+
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TurnCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TurnCommand.java
@@ -12,6 +12,8 @@ public class TurnCommand extends CommandBase {
     public TurnCommand(MecanumDriveSubsystem drive, double angle) {
         this.drive = drive;
         this.angle = angle;
+        
+        addRequirements(drive);
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/BackAndForth.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/BackAndForth.java
@@ -54,7 +54,7 @@ public class BackAndForth extends CommandOpMode {
                     .build()
         );
         SequentialCommandGroup backAndForthCommand = new SequentialCommandGroup(forwardFollower, backwardFollower);
-        schedule(new PerpetualCommand(new ScheduleCommand( new InstantCommand(
+        schedule(new PerpetualCommand(new ScheduleCommand(new InstantCommand(
                 () -> {
                     if (backAndForthCommand.isFinished() || !backAndForthCommand.isScheduled()) {
                         backAndForthCommand.schedule();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/BackAndForth.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/BackAndForth.java
@@ -6,6 +6,7 @@ import com.acmerobotics.roadrunner.trajectory.Trajectory;
 import com.arcrobotics.ftclib.command.CommandOpMode;
 import com.arcrobotics.ftclib.command.InstantCommand;
 import com.arcrobotics.ftclib.command.PerpetualCommand;
+import com.arcrobotics.ftclib.command.ScheduleCommand;
 import com.arcrobotics.ftclib.command.SequentialCommandGroup;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
@@ -53,13 +54,13 @@ public class BackAndForth extends CommandOpMode {
                     .build()
         );
         SequentialCommandGroup backAndForthCommand = new SequentialCommandGroup(forwardFollower, backwardFollower);
-        schedule(new PerpetualCommand(new InstantCommand(
+        schedule(new PerpetualCommand(new ScheduleCommand( new InstantCommand(
                 () -> {
                     if (backAndForthCommand.isFinished() || !backAndForthCommand.isScheduled()) {
                         backAndForthCommand.schedule();
                     }
                 }
-        )));
+        ))));
     }
 
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
@@ -5,6 +5,7 @@ import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.arcrobotics.ftclib.command.CommandOpMode;
 import com.arcrobotics.ftclib.command.InstantCommand;
 import com.arcrobotics.ftclib.command.PerpetualCommand;
+import com.arcrobotics.ftclib.command.ScheduleCommand;
 import com.arcrobotics.ftclib.gamepad.GamepadEx;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
@@ -35,7 +36,7 @@ public class LocalizationTest extends CommandOpMode {
     public void initialize() {
         drive = new MecanumDriveSubsystem(new SampleMecanumDrive(hardwareMap), false);
 
-        schedule(new PerpetualCommand(new InstantCommand(
+        schedule(new PerpetualCommand(new ScheduleCommand( new InstantCommand(
                 () -> {
                     Pose2d poseEstimate = drive.getPoseEstimate();
                     telemetry.addData("x", poseEstimate.getX());
@@ -43,7 +44,7 @@ public class LocalizationTest extends CommandOpMode {
                     telemetry.addData("heading", poseEstimate.getHeading());
                     telemetry.update();
                 }   // ignore requirements
-        )));
+        ))));
 
         driveCommand = new MecanumDriveCommand(
                 drive, () -> -gamepad.getLeftY(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
@@ -36,7 +36,7 @@ public class LocalizationTest extends CommandOpMode {
     public void initialize() {
         drive = new MecanumDriveSubsystem(new SampleMecanumDrive(hardwareMap), false);
 
-        schedule(new PerpetualCommand(new ScheduleCommand( new InstantCommand(
+        schedule(new PerpetualCommand(new ScheduleCommand(new InstantCommand(
                 () -> {
                     Pose2d poseEstimate = drive.getPoseEstimate();
                     telemetry.addData("x", poseEstimate.getX());

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
@@ -2,11 +2,17 @@ package org.firstinspires.ftc.teamcode.drive.opmode;
 
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
+import com.arcrobotics.ftclib.command.CommandOpMode;
+import com.arcrobotics.ftclib.command.InstantCommand;
+import com.arcrobotics.ftclib.command.PerpetualCommand;
+import com.arcrobotics.ftclib.gamepad.GamepadEx;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
 
+import org.firstinspires.ftc.teamcode.commands.MecanumDriveCommand;
 import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
+import org.firstinspires.ftc.teamcode.subsystems.MecanumDriveSubsystem;
 
 /**
  * This is a simple teleop routine for testing localization. Drive the robot around like a normal
@@ -14,34 +20,37 @@ import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
  * errors are not out of the ordinary, especially with sudden drive motions). The goal of this
  * exercise is to ascertain whether the localizer has been configured properly (note: the pure
  * encoder localizer heading may be significantly off if the track width has not been tuned).
+ *
+ * NOTE: this has been refactored to use FTCLib's command-based
  */
 @Config
 @TeleOp(group = "drive")
-public class LocalizationTest extends LinearOpMode {
+public class LocalizationTest extends CommandOpMode {
+
+    private MecanumDriveSubsystem drive;
+    private MecanumDriveCommand driveCommand;
+    private GamepadEx gamepad;
+
     @Override
-    public void runOpMode() throws InterruptedException {
-        SampleMecanumDrive drive = new SampleMecanumDrive(hardwareMap);
+    public void initialize() {
+        drive = new MecanumDriveSubsystem(new SampleMecanumDrive(hardwareMap), false);
 
-        drive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+        schedule(new PerpetualCommand(new InstantCommand(
+                () -> {
+                    Pose2d poseEstimate = drive.getPoseEstimate();
+                    telemetry.addData("x", poseEstimate.getX());
+                    telemetry.addData("y", poseEstimate.getY());
+                    telemetry.addData("heading", poseEstimate.getHeading());
+                    telemetry.update();
+                }   // ignore requirements
+        )));
 
-        waitForStart();
+        driveCommand = new MecanumDriveCommand(
+                drive, () -> -gamepad.getLeftY(),
+                gamepad::getLeftX, gamepad::getRightX
+        );
 
-        while (!isStopRequested()) {
-            drive.setWeightedDrivePower(
-                    new Pose2d(
-                            -gamepad1.left_stick_y,
-                            -gamepad1.left_stick_x,
-                            -gamepad1.right_stick_x
-                    )
-            );
-
-            drive.update();
-
-            Pose2d poseEstimate = drive.getPoseEstimate();
-            telemetry.addData("x", poseEstimate.getX());
-            telemetry.addData("y", poseEstimate.getY());
-            telemetry.addData("heading", poseEstimate.getHeading());
-            telemetry.update();
-        }
+        schedule(driveCommand);
     }
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/SplineTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/SplineTest.java
@@ -3,36 +3,40 @@ package org.firstinspires.ftc.teamcode.drive.opmode;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.acmerobotics.roadrunner.geometry.Vector2d;
 import com.acmerobotics.roadrunner.trajectory.Trajectory;
+import com.arcrobotics.ftclib.command.CommandOpMode;
+import com.arcrobotics.ftclib.command.WaitCommand;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
+import org.firstinspires.ftc.teamcode.commands.TrajectoryFollowerCommand;
 import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
+import org.firstinspires.ftc.teamcode.subsystems.MecanumDriveSubsystem;
 
-/*
+/**
  * This is an example of a more complex path to really test the tuning.
+ *
+ * NOTE: this has been refactored to use FTCLib's command-based
  */
 @Autonomous(group = "drive")
-public class SplineTest extends LinearOpMode {
+public class SplineTest extends CommandOpMode {
+
+    private MecanumDriveSubsystem drive;
+    private TrajectoryFollowerCommand splineFollower;
+
     @Override
-    public void runOpMode() throws InterruptedException {
-        SampleMecanumDrive drive = new SampleMecanumDrive(hardwareMap);
-
-        waitForStart();
-
-        if (isStopRequested()) return;
-
+    public void initialize() {
+        drive = new MecanumDriveSubsystem(new SampleMecanumDrive(hardwareMap), false);
         Trajectory traj = drive.trajectoryBuilder(new Pose2d())
                 .splineTo(new Vector2d(30, 30), 0)
                 .build();
-
-        drive.followTrajectory(traj);
-
-        sleep(2000);
-
-        drive.followTrajectory(
+        splineFollower = new TrajectoryFollowerCommand(drive, traj);
+        schedule(splineFollower.andThen(new WaitCommand(2000),
+            new TrajectoryFollowerCommand(drive,
                 drive.trajectoryBuilder(traj.end(), true)
-                        .splineTo(new Vector2d(0, 0), Math.toRadians(180))
-                        .build()
+                    .splineTo(new Vector2d(0, 0), Math.toRadians(180))
+                    .build()
+            ))
         );
     }
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/StrafeTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/StrafeTest.java
@@ -3,39 +3,43 @@ package org.firstinspires.ftc.teamcode.drive.opmode;
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.acmerobotics.roadrunner.trajectory.Trajectory;
+import com.arcrobotics.ftclib.command.CommandOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
+import org.firstinspires.ftc.teamcode.commands.TrajectoryFollowerCommand;
 import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
+import org.firstinspires.ftc.teamcode.subsystems.MecanumDriveSubsystem;
 
-/*
+/**
  * This is a simple routine to test translational drive capabilities.
+ *
+ * NOTE: this has been refactored to use FTCLib's command-based
  */
 @Config
 @Autonomous(group = "drive")
-public class StrafeTest extends LinearOpMode {
+public class StrafeTest extends CommandOpMode {
+
     public static double DISTANCE = 60; // in
 
+    private MecanumDriveSubsystem drive;
+    private TrajectoryFollowerCommand strafeFollower;
+
     @Override
-    public void runOpMode() throws InterruptedException {
-        SampleMecanumDrive drive = new SampleMecanumDrive(hardwareMap);
-
-        Trajectory trajectory = drive.trajectoryBuilder(new Pose2d())
-                .strafeRight(DISTANCE)
-                .build();
-
-        waitForStart();
-
-        if (isStopRequested()) return;
-
-        drive.followTrajectory(trajectory);
-
-        Pose2d poseEstimate = drive.getPoseEstimate();
-        telemetry.addData("finalX", poseEstimate.getX());
-        telemetry.addData("finalY", poseEstimate.getY());
-        telemetry.addData("finalHeading", poseEstimate.getHeading());
-        telemetry.update();
-
-        while (!isStopRequested() && opModeIsActive()) ;
+    public void initialize() {
+        drive = new MecanumDriveSubsystem(new SampleMecanumDrive(hardwareMap), false);
+        strafeFollower = new TrajectoryFollowerCommand(drive,
+                drive.trajectoryBuilder(new Pose2d())
+                    .strafeRight(DISTANCE)
+                    .build()
+        );
+        schedule(strafeFollower.whenFinished(() -> {
+            Pose2d poseEstimate = drive.getPoseEstimate();
+            telemetry.addData("finalX", poseEstimate.getX());
+            telemetry.addData("finalY", poseEstimate.getY());
+            telemetry.addData("finalHeading", poseEstimate.getHeading());
+            telemetry.update();
+        }));
     }
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/StraightTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/StraightTest.java
@@ -2,40 +2,42 @@ package org.firstinspires.ftc.teamcode.drive.opmode;
 
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
-import com.acmerobotics.roadrunner.trajectory.Trajectory;
+import com.arcrobotics.ftclib.command.CommandOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
-import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
+import org.firstinspires.ftc.teamcode.commands.TrajectoryFollowerCommand;
 import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
+import org.firstinspires.ftc.teamcode.subsystems.MecanumDriveSubsystem;
 
-/*
+/**
  * This is a simple routine to test translational drive capabilities.
+ *
+ * NOTE: this has been refactored to use FTCLib's command-based
  */
 @Config
 @Autonomous(group = "drive")
-public class StraightTest extends LinearOpMode {
+public class StraightTest extends CommandOpMode {
+
     public static double DISTANCE = 60; // in
 
+    private MecanumDriveSubsystem drive;
+    private TrajectoryFollowerCommand straightFollower;
+
     @Override
-    public void runOpMode() throws InterruptedException {
-        SampleMecanumDrive drive = new SampleMecanumDrive(hardwareMap);
-
-        Trajectory trajectory = drive.trajectoryBuilder(new Pose2d())
-                .forward(DISTANCE)
-                .build();
-
-        waitForStart();
-
-        if (isStopRequested()) return;
-
-        drive.followTrajectory(trajectory);
-
-        Pose2d poseEstimate = drive.getPoseEstimate();
-        telemetry.addData("finalX", poseEstimate.getX());
-        telemetry.addData("finalY", poseEstimate.getY());
-        telemetry.addData("finalHeading", poseEstimate.getHeading());
-        telemetry.update();
-
-        while (!isStopRequested() && opModeIsActive()) ;
+    public void initialize() {
+        drive = new MecanumDriveSubsystem(new SampleMecanumDrive(hardwareMap), false);
+        straightFollower = new TrajectoryFollowerCommand(drive,
+                drive.trajectoryBuilder(new Pose2d())
+                    .forward(DISTANCE)
+                    .build()
+        );
+        schedule(straightFollower.whenFinished(() -> {
+            Pose2d poseEstimate = drive.getPoseEstimate();
+            telemetry.addData("finalX", poseEstimate.getX());
+            telemetry.addData("finalY", poseEstimate.getY());
+            telemetry.addData("finalHeading", poseEstimate.getHeading());
+            telemetry.update();
+        }));
     }
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/TurnTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/TurnTest.java
@@ -1,27 +1,40 @@
 package org.firstinspires.ftc.teamcode.drive.opmode;
 
 import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.roadrunner.geometry.Pose2d;
+import com.arcrobotics.ftclib.command.CommandOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
+import org.firstinspires.ftc.teamcode.commands.TurnCommand;
 import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
+import org.firstinspires.ftc.teamcode.subsystems.MecanumDriveSubsystem;
 
-/*
+/**
  * This is a simple routine to test turning capabilities.
+ *
+ * NOTE: this has been refactored to use FTCLib's command-based
  */
 @Config
 @Autonomous(group = "drive")
-public class TurnTest extends LinearOpMode {
+public class TurnTest extends CommandOpMode {
+
     public static double ANGLE = 90; // deg
 
+    private MecanumDriveSubsystem drive;
+    private TurnCommand turnCommand;
+
     @Override
-    public void runOpMode() throws InterruptedException {
-        SampleMecanumDrive drive = new SampleMecanumDrive(hardwareMap);
-
-        waitForStart();
-
-        if (isStopRequested()) return;
-
-        drive.turn(Math.toRadians(ANGLE));
+    public void initialize() {
+        drive = new MecanumDriveSubsystem(new SampleMecanumDrive(hardwareMap), false);
+        turnCommand = new TurnCommand(drive, Math.toRadians(ANGLE));
+        schedule(turnCommand.whenFinished(() -> {
+            Pose2d poseEstimate = drive.getPoseEstimate();
+            telemetry.addData("finalX", poseEstimate.getX());
+            telemetry.addData("finalY", poseEstimate.getY());
+            telemetry.addData("finalHeading", poseEstimate.getHeading());
+            telemetry.update();
+        }));
     }
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Pose2dUtil.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Pose2dUtil.kt
@@ -1,0 +1,23 @@
+package org.firstinspires.ftc.teamcode.util
+
+import com.acmerobotics.roadrunner.geometry.Pose2d
+import com.arcrobotics.ftclib.geometry.Rotation2d
+import com.arcrobotics.ftclib.kinematics.wpilibkinematics.ChassisSpeeds
+
+fun com.arcrobotics.ftclib.geometry.Pose2d.toRR(): Pose2d = Pose2d(this.translation.y, this.translation.x, this.heading)
+
+fun Pose2d.toFTCLib(): com.arcrobotics.ftclib.geometry.Pose2d = com.arcrobotics.ftclib.geometry.Pose2d(-this.x, -this.y, Rotation2d(this.heading))
+
+val com.arcrobotics.ftclib.geometry.Pose2d.x: Double
+    get() = this.translation.x
+
+val com.arcrobotics.ftclib.geometry.Pose2d.y: Double
+    get() = this.translation.y
+
+val com.arcrobotics.ftclib.geometry.Pose2d.rotationDeg: Double
+    get() = this.rotation.degrees
+
+val com.arcrobotics.ftclib.geometry.Pose2d.rotationRad: Double
+    get() = this.rotation.radians
+
+fun ChassisSpeeds.toRRPose2d(): Pose2d = Pose2d(this.vxMetersPerSecond, this.vyMetersPerSecond, this.omegaRadiansPerSecond)


### PR DESCRIPTION
closes #1 and #2 

Sets up three commands:
* `MecanumDriveCommand`: basic power control of the mecanum drive
* `TurnCommand`: performs an async turn until finished (idiomatic paradigm-following for command-based)
* `TrajectoryFollowerCommand`: performs an async follow until finished (same logic as `TurnCommand`)

All three of these commands require the `MecanumDriveSubsystem` which contains all of the logic for performing these commands.